### PR TITLE
Add request and response types

### DIFF
--- a/endpoint.go
+++ b/endpoint.go
@@ -1,21 +1,21 @@
 package mockapi
 
-type BodyType string
+type BodyFormat string
 
 const (
-	BodyTypeNone   BodyType = "none"
-	BodyTypeJSON   BodyType = "json"
-	BodyTypeString BodyType = "string"
-	BodyTypeStream BodyType = "stream"
+	BodyFormatNone   BodyFormat = "none"
+	BodyFormatJSON   BodyFormat = "json"
+	BodyFormatString BodyFormat = "string"
+	BodyFormatStream BodyFormat = "stream"
 )
 
-type ResponseType string
+type ResponseFormat string
 
 const (
-	ResponseTypeJSON   ResponseType = "json"
-	ResponseTypeString ResponseType = "string"
-	ResponseTypeStream ResponseType = "stream"
-	ResponseTypeFunc   ResponseType = "func"
+	ResponseFormatJSON   ResponseFormat = "json"
+	ResponseFormatString ResponseFormat = "string"
+	ResponseFormatStream ResponseFormat = "stream"
+	ResponseFormatFunc   ResponseFormat = "func"
 )
 
 // Endpoint represents an HTTP endpoint to be mocked.
@@ -26,12 +26,17 @@ type Endpoint struct {
 	Path string
 	// Method is the HTTP Method used to invoke this API
 	Method string
-	// BodyType is what type of body to take as input
-	BodyType BodyType
+	// BodyFormat is what format of body to take as input
+	BodyFormat BodyFormat
+	// BodyType is the golang type of the Body
+	BodyType string
+
 	// PathParameters are the parameters required to be in the path
 	PathParameters []string
-	// ResponseType is the type of Response that helpers should
-	ResponseType ResponseType
+	// ResponseFormat is the format of Response that helpers should
+	ResponseFormat ResponseFormat
+	// ResponseType is the golang type of the Response
+	ResponseType string
 	// Headers indicates that this endpoints operation is influenced by
 	// headers which may be present and so the headers should be a part
 	// of the expectation

--- a/mock.go
+++ b/mock.go
@@ -217,7 +217,7 @@ func (m *MockAPI) WithNoResponseBody(req *MockRequest, status int) *MockAPICall 
 	})
 }
 
-// WithTxtReply will setup an expectation for an API call to be made. The supplied status code will
+// WithJSONReply will setup an expectation for an API call to be made. The supplied status code will
 // be use for the responses reply and the reply object will be JSON encoded and written to the response. If there is
 // an error in JSON encoding it will fail the test object passed into the NewMockAPI constructor if that
 // was non-nil and if it was nil, will panic. The method, path and body parameters are the same as for
@@ -241,9 +241,9 @@ func (m *MockAPI) WithJSONReply(req *MockRequest, status int, reply interface{})
 	})
 }
 
-// WithTxtReply will setup an expectation for an API call to be made. The supplied status code will
+// WithTextReply will setup an expectation for an API call to be made. The supplied status code will
 // be use for the responses reply and the reply string will be written to the response.
-func (m *MockAPI) WithTxtReply(req *MockRequest, status int, reply string) *MockAPICall {
+func (m *MockAPI) WithTextReply(req *MockRequest, status int, reply string) *MockAPICall {
 	return m.WithRequest(req, func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(status)
 		w.Write([]byte(reply))


### PR DESCRIPTION
## Overview
* Uses `text/template` over `html/template` to avoid special characters escaping. For example the string value `"` would escape to `&#34;`
* Renames `BodyType` and `ReponseType` to *Format which describes the format of the request and response
* Adds new input for `BodyType` and `ResponseType` to specify the Go type for request and response bodies
  * Default body type for JSON format remains as `map[string]interface{}`
  * Default response type for JSON format remains as `interface{}`
* Adds support to specify package imports to reference Go types from different packages

## Breaking Changes
The JSON input file format changes from 
```
{
  "<funcName>": {
    // endpoint info
    // ...
    "BodyType": "json",
    "ResponseType": "json"
  }
}
```

```
{
  "imports": {
    "<pkgName>": "github.com/org/repo/pkg"
  },
  "endpoints": {
    "<funcName>": {
      // ...
      "BodyFormat": "json",
      "BodyType": "*api.ACLLoginParams",
      "ResponseFormat": "json",
      "ResponseType": "*api.ACLToken"
    }
  }
}
```